### PR TITLE
SyncNewAutoPilotComputersandUsersToAAD: Test if usercertificate attribute has been updated instead of Modified and Created

### DIFF
--- a/SyncNewAutoPilotComputersandUsersToAAD.ps1
+++ b/SyncNewAutoPilotComputersandUsersToAAD.ps1
@@ -22,7 +22,7 @@ $computers = Get-ADComputer -Filter 'Modified -ge $time' -SearchBase "OU=AutoPil
 $users = Get-ADUser -Filter 'Created -ge $time' -SearchBase "OU=W10Users,OU=Users,DC=somedomain,DC=com" -Properties Created
 $dc = Get-ADDomainController -Discover
 
-If ($computers -ne $null) {
+If ($null -ne $computers) {
     ForEach ($computer in $computers) {
         $replicationmetadata = Get-ADReplicationAttributeMetadata -Object $computer -Server $dc -Properties userCertificate
         If (($replicationmetadata.LastOriginatingChangeTime -ge $time) -And ($computer.userCertificate)) {
@@ -35,7 +35,7 @@ If ($computers -ne $null) {
     Start-Sleep -Seconds 30
 }
 
-If (($syncComputers -ne $null) -Or ($users -ne $null)) {
+If (($null -ne $syncComputers) -Or ($null -ne $users)) {
     Try { Start-ADSyncSyncCycle -PolicyType Delta }
     Catch {}
 }

--- a/SyncNewAutoPilotComputersandUsersToAAD.ps1
+++ b/SyncNewAutoPilotComputersandUsersToAAD.ps1
@@ -9,7 +9,7 @@
 # and helps to avoid the 3rd authentication prompt.
 #
 # Only devices with a userCertificate attribute are synced, so this script only attempts
-# to sync devices that have been created within the last 5 hours and have the attribute set,
+# to sync devices that have this attribute updated in the last 5 minutes and have the attribute set,
 # which is checked every 5 minutes via any changes in the object's Modified time.
 #
 # Install this as a scheduled task that runs every 5 minutes on your AADConnect server.


### PR DESCRIPTION
Fixes #2 - it's possible to test to see if the userCertificate attribute itself has been updated (using Get-ADReplicationAttributeMetadata), which means there's no need to compare Modified and Created to make sure it was created within the last 5 hours

It will also mean computers leaving Hybrid Azure AD and then rejoining (using dscmd.exe /leave, which clears/recreates 'usercertificate' without updating 'Created') can also be detected and synced more quickly.

I've also updated a couple of $null comparators so they meet PowerShell [best practice](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/PossibleIncorrectComparisonWithNull.md)
